### PR TITLE
updates json assertion according to latest XLSX update

### DIFF
--- a/tests/features/StructureValidationTest.php
+++ b/tests/features/StructureValidationTest.php
@@ -49,7 +49,7 @@ class StructureValidationTest extends TestCase
         ])->assertStatus(200)
         ->assertJsonFragment([
             'errors' => [
-                'Extra Sheets' => ['invalidSheet'],
+                'Extra Sheets' => ['invalid_sheet'],
                 'Missing Sheets' => ['groups']
             ],
             'filename' => self::TestFile,


### PR DESCRIPTION
The lastest update in XLSX.php, changes `Str::camel` to `Str::snake`. The `StructureValidationTest` fails now, because it asserts a camel case name in the json response. This pull request changes it to a snake case name.