### PR TITLE
adds customization for select labels

### DIFF
--- a/src/Attributes/Param.php
+++ b/src/Attributes/Param.php
@@ -6,7 +6,9 @@ class Param extends Attribute
 {
     public const Mandatory = ['name', 'type'];
 
-    public const Optional = ['validations', 'multiple', 'route', 'params', 'custom', 'label',  'value'];
+    public const Optional = [
+        'validations', 'multiple', 'route', 'params', 'custom', 'label',  'value', 'selectLabel',
+    ];
 
     public const Dependent = [
         'select' => ['route'],


### PR DESCRIPTION
Having a select component for choosing import params wouldn't work when the options need a custom label.

For example, the label for the user options is `person.name` instead of the default, `name`.

This should go in conjunction with: https://github.com/enso-ui/data-import/pull/5